### PR TITLE
fix links to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,8 +11,8 @@ Authors@R:
     )
 Description: The method of synthetic controls is a widely-adopted tool for evaluating causal effects of policy changes in settings with observational data. In many settings where it is applicable, researchers want to identify causal effects of policy changes on a treated unit at an aggregate level while having access to data at a finer granularity. This package implements a simple extension of the synthetic controls estimator, developed in Gunsilius (2023) <doi:10.3982/ECTA18260>, that takes advantage of this additional structure and provides nonparametric estimates of the heterogeneity within the aggregate unit. The idea is to replicate the quantile function associated with the treated unit by a weighted average of quantile functions of the control units. The package contains tools for aggregating and plotting the resulting distributional estimates, as well as for carrying out inference on them. 
 License: MIT + file LICENSE
-BugReports: https://github.com/
-URL: <link href="https://github.com/" rel="canonical">, <link href="http://www.davidvandijcke.com/DiSCos/" rel="canonical"> 
+BugReports: https://github.com/Davidvandijcke/DiSCos/issues
+URL: http://www.davidvandijcke.com/DiSCos/, https://github.com/Davidvandijcke/DiSCos
 LazyData: TRUE
 Imports: CVXR, pracma, Rdpack, parallel, evmix, utils, extremeStat, MASS
 Depends: 


### PR DESCRIPTION
CRAN doesn't need to have markup in the URL field. 

This fixes the problem!